### PR TITLE
Add support for customizable pagination templates

### DIFF
--- a/lib/pagination_ex.ex
+++ b/lib/pagination_ex.ex
@@ -19,5 +19,35 @@ defmodule PaginationEx do
   @doc """
   Renders pagination links in HTML.
   """
-  defdelegate paginate(conn, path), to: HTML
+  defdelegate paginate(conn, path, opts \\ []), to: HTML
+
+  @doc """
+  Generates the "Next" link or disabled button based on the current page and total pages.
+  Useful for custom pagination templates.
+  """
+  defdelegate next_path(conn, path, current_page, total_pages), to: HTML
+
+  @doc """
+  Generates the "Previous" link or disabled button based on the current page.
+  Useful for custom pagination templates.
+  """
+  defdelegate previous_path(conn, path, current_page), to: HTML
+
+  @doc """
+  Generates numeric links for each page.
+  Useful for custom pagination templates.
+  """
+  defdelegate page_links(conn, path, pagination), to: HTML
+
+  @doc """
+  Builds the URL for a specific page.
+  Useful for custom pagination templates.
+  """
+  defdelegate build_url(conn, path, page), to: HTML
+
+  @doc """
+  Translates text using configured Gettext module if available.
+  Useful for custom pagination templates.
+  """
+  defdelegate translate(text), to: HTML
 end

--- a/test/pagination_ex/html_test.exs
+++ b/test/pagination_ex/html_test.exs
@@ -18,7 +18,7 @@ defmodule PaginationEx.HTMLTest do
     {:ok, conn: conn}
   end
 
-  describe "paginate/2" do
+  describe "paginate/3 with default template" do
     test "renders basic pagination", %{conn: conn} do
       result =
         conn
@@ -53,7 +53,10 @@ defmodule PaginationEx.HTMLTest do
         |> Phoenix.HTML.Safe.to_iodata()
         |> IO.iodata_to_binary()
 
-      assert result =~ ~s(cursor-not-allowed" disabled>Previous)
+      assert result =~ "disabled"
+      assert result =~ "cursor-not-allowed"
+      assert result =~ "Previous"
+      refute result =~ "href=\"/test?page=0\""
     end
 
     test "disables next on last page", %{conn: conn} do
@@ -65,7 +68,10 @@ defmodule PaginationEx.HTMLTest do
         |> Phoenix.HTML.Safe.to_iodata()
         |> IO.iodata_to_binary()
 
-      assert result =~ ~s(cursor-not-allowed" disabled>Next)
+      assert result =~ "disabled"
+      assert result =~ "cursor-not-allowed"
+      assert result =~ "Next"
+      refute result =~ "href=\"/test?page=5\""
     end
 
     test "includes proper ARIA attributes", %{conn: conn} do
@@ -82,9 +88,47 @@ defmodule PaginationEx.HTMLTest do
     test "handles no results", %{conn: conn} do
       conn = put_in(conn.assigns.pagination.total_entries, 0)
       conn = put_in(conn.assigns.pagination.per_page, 10)
-
       result = PaginationEx.paginate(conn, "/test")
+      assert result == nil
+    end
+  end
 
+  describe "paginate/3 with custom template" do
+    defmodule TestTemplateModule do
+      use PhoenixHTMLHelpers
+
+      def render_pagination(_conn, _path, %{total_entries: total_entries, per_page: per_page})
+          when total_entries < per_page,
+          do: nil
+
+      def render_pagination(_conn, _path, %{page_number: current_page, pages: total_pages}) do
+        content_tag(
+          :div,
+          [
+            content_tag(:p, "Custom Pages: #{current_page}/#{total_pages}"),
+            content_tag(:div, "Custom Pagination")
+          ],
+          class: "custom-pagination"
+        )
+      end
+    end
+
+    test "uses custom template when provided", %{conn: conn} do
+      result =
+        conn
+        |> PaginationEx.paginate("/test", template_module: TestTemplateModule)
+        |> Phoenix.HTML.Safe.to_iodata()
+        |> IO.iodata_to_binary()
+
+      assert result =~ "Custom Pages: 2/4"
+      assert result =~ "Custom Pagination"
+      assert result =~ "custom-pagination"
+    end
+
+    test "custom template handles no results", %{conn: conn} do
+      conn = put_in(conn.assigns.pagination.total_entries, 0)
+      conn = put_in(conn.assigns.pagination.per_page, 10)
+      result = PaginationEx.paginate(conn, "/test", template_module: TestTemplateModule)
       assert result == nil
     end
   end


### PR DESCRIPTION
#### Description

This commit adds support for customizable pagination templates, allowing users to define their own styling and layout. 

The solution introduces a template_module option that accepts a module which implements a render_pagination/3 function. This enables users to create templates with different CSS frameworks (like Bootstrap or Tailwind) while keeping the core pagination logic intact.

Additionally, several helper functions were made public to facilitate template creation, including build_url, translate, previous_path, and next_path.

#### Screencast

https://github.com/user-attachments/assets/91f28e0d-e32e-4acc-bd9b-b28937e54a07