### PR TITLE
Fix pagination count for queries with GROUP BY clauses

### DIFF
--- a/test/pagination_ex/core_test.exs
+++ b/test/pagination_ex/core_test.exs
@@ -3,6 +3,7 @@ defmodule PaginationEx.CoreTest do
   use Ecto.Schema
 
   import Ecto.Query
+  require Logger
 
   @default_per_page 30
 
@@ -23,22 +24,42 @@ defmodule PaginationEx.CoreTest do
   end
 
   setup_all do
+    original_log_level = Logger.level()
+    original_backends = :logger.get_handler_config()
+
+    Logger.configure(level: :error)
+    :logger.remove_handler(:default)
+
     Application.put_env(:pagination_ex, TestRepo,
       username: "postgres",
       password: "postgres",
       hostname: "localhost",
       port: 5432,
       database: "pagination_ex_test",
-      pool: Ecto.Adapters.SQL.Sandbox
+      pool: Ecto.Adapters.SQL.Sandbox,
+      log: false
     )
 
+    Application.put_env(:ecto, :logger, false)
+    Application.put_env(:postgrex, :debug_logger, false)
+
     TestRepo.start_link()
+
+    on_exit(fn ->
+      Logger.configure(level: original_log_level)
+
+      :logger.add_handler(:default, :logger_std_h, %{
+        config: %{type: :standard_io},
+        formatter: original_backends[:default][:formatter]
+      })
+    end)
 
     :ok
   end
 
   setup do
-    TestRepo.query!("DROP TABLE IF EXISTS test_items")
+    TestRepo.query!("DROP TABLE IF EXISTS test_item_details CASCADE")
+    TestRepo.query!("DROP TABLE IF EXISTS test_items CASCADE")
 
     TestRepo.query!("""
       CREATE TABLE IF NOT EXISTS test_items (
@@ -50,6 +71,15 @@ defmodule PaginationEx.CoreTest do
       )
     """)
 
+    TestRepo.query!("""
+      CREATE TABLE IF NOT EXISTS test_item_details (
+        id serial primary key,
+        item_id integer references test_items(id),
+        details text,
+        tag text
+      )
+    """)
+
     for i <- 1..30 do
       TestRepo.query!(
         "INSERT INTO test_items (name, category) VALUES ($1, $2)",
@@ -58,7 +88,6 @@ defmodule PaginationEx.CoreTest do
     end
 
     Application.put_env(:pagination_ex, :repo, TestRepo)
-
     :ok
   end
 
@@ -200,6 +229,205 @@ defmodule PaginationEx.CoreTest do
 
       assert result.per_page == 999_999
       assert length(result.entries) == 30
+    end
+
+    test "successfully paginates with GROUP BY query" do
+      query =
+        from(i in TestSchema,
+          group_by: i.category,
+          select: {i.category, count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.page_number == 1
+      assert result.total_entries == 4
+      assert result.pages == 1
+      assert length(result.entries) == 4
+    end
+
+    test "paginates GROUP BY query with custom page and per_page" do
+      query =
+        from(i in TestSchema,
+          group_by: i.category,
+          select: {i.category, count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{"page" => "1", "per_page" => "2"})
+
+      assert result.page_number == 1
+      assert result.per_page == 2
+      assert result.total_entries == 4
+      assert result.pages == 2
+      assert length(result.entries) == 2
+    end
+
+    test "handles empty result set with GROUP BY" do
+      query =
+        from(i in TestSchema,
+          where: i.name == "NonExistent",
+          group_by: i.category,
+          select: {i.category, count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.page_number == 1
+      assert result.total_entries == 0
+      assert result.pages == 0
+      assert length(result.entries) == 0
+    end
+
+    test "successfully paginates with GROUP BY and ORDER BY" do
+      query =
+        from(i in TestSchema,
+          group_by: i.category,
+          order_by: [desc: count(i.id)],
+          select: {i.category, count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.page_number == 1
+      assert result.total_entries == 4
+      assert result.pages == 1
+      assert length(result.entries) == 4
+    end
+
+    test "handles complex GROUP BY with multiple grouping expressions" do
+      for i <- 1..10 do
+        TestRepo.query!(
+          "INSERT INTO test_items (name, category) VALUES ($1, $2)",
+          ["Extra Item #{i}", "Extra Category"]
+        )
+      end
+
+      query =
+        from(i in TestSchema,
+          group_by: [i.category, fragment("date_trunc('day', ?)", i.inserted_at)],
+          select: {i.category, fragment("date_trunc('day', ?)", i.inserted_at), count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.total_entries == 5
+      assert length(result.entries) == 5
+    end
+
+    test "handles DISTINCT queries" do
+      for _ <- 1..5 do
+        TestRepo.query!(
+          "INSERT INTO test_items (name, category) VALUES ($1, $2)",
+          ["Duplicate Item", "Duplicate Category"]
+        )
+      end
+
+      query =
+        from(i in TestSchema,
+          distinct: i.category,
+          select: i.category
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.total_entries == 5
+      assert length(result.entries) == 5
+    end
+
+    test "handles queries with JOIN" do
+      for i <- 1..10 do
+        TestRepo.query!(
+          "INSERT INTO test_item_details (item_id, details) VALUES ($1, $2)",
+          [i, "Details for item #{i}"]
+        )
+      end
+
+      query =
+        from(i in TestSchema,
+          join: d in "test_item_details",
+          on: i.id == d.item_id,
+          select: {i.id, i.name, d.details}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.total_entries == 10
+      assert length(result.entries) == 10
+    end
+
+    test "handles queries with JOIN and GROUP BY" do
+      for i <- 1..10 do
+        tag = (rem(i, 3) == 0 && "tag_a") || "tag_b"
+
+        TestRepo.query!(
+          "INSERT INTO test_item_details (item_id, details, tag) VALUES ($1, $2, $3)",
+          [i, "Details for item #{i}", tag]
+        )
+      end
+
+      query =
+        from(i in TestSchema,
+          join: d in "test_item_details",
+          on: i.id == d.item_id,
+          group_by: d.tag,
+          select: {d.tag, count(i.id)}
+        )
+
+      result = PaginationEx.new(query, %{})
+
+      assert result.total_entries == 2
+      assert length(result.entries) == 2
+    end
+
+    test "performance of count with large dataset" do
+      TestRepo.query!("TRUNCATE test_items RESTART IDENTITY CASCADE")
+
+      batch_size = 100
+      total_records = 1000
+
+      for batch <- 0..div(total_records - 1, batch_size) do
+        params =
+          for i <- 1..batch_size do
+            index = batch * batch_size + i
+            category = "Category #{div(index, 100)}"
+            ["Item #{index}", category]
+          end
+
+        placeholders =
+          params
+          |> Enum.with_index()
+          |> Enum.map(fn {_, idx} -> "($#{idx * 2 + 1}, $#{idx * 2 + 2})" end)
+          |> Enum.join(", ")
+
+        values = params |> List.flatten()
+
+        TestRepo.query!(
+          "INSERT INTO test_items (name, category) VALUES " <> placeholders,
+          values
+        )
+      end
+
+      {time_normal, result_normal} =
+        :timer.tc(fn ->
+          query = from(i in TestSchema)
+          PaginationEx.new(query, %{})
+        end)
+
+      {time_group, result_group} =
+        :timer.tc(fn ->
+          query =
+            from(i in TestSchema,
+              group_by: i.category,
+              select: {i.category, count(i.id)}
+            )
+
+          PaginationEx.new(query, %{})
+        end)
+
+      assert result_normal.total_entries == total_records
+      assert result_group.total_entries >= 10 && result_group.total_entries <= 11
+
+      assert time_group < time_normal * 10, "GROUP BY query time should not be excessive"
     end
   end
 end


### PR DESCRIPTION
### Description
This fix addresses an issue where the pagination library would fail when used with queries containing a GROUP BY clause. The error occurred because the COUNT aggregate function couldn't be used directly with GROUP BY without being part of the grouped columns.

#### Key Changes:
1. Added intelligent query type detection to identify simple queries, queries with GROUP BY, DISTINCT, or complex JOINs
2. Implemented optimized count strategies based on query type:
   - Simple queries use direct counting with minimal overhead
   - GROUP BY and DISTINCT queries use Common Table Expressions (CTEs) for efficient counting
   - All count queries exclude unnecessary clauses like ORDER BY and PRELOAD for better performance

#### Test Coverage:
- Added comprehensive tests for GROUP BY scenarios:
  - Basic GROUP BY queries
  - GROUP BY with custom pagination parameters
  - GROUP BY with ORDER BY clauses
  - Complex GROUP BY with multiple grouping expressions
  - GROUP BY combined with JOINs
  - DISTINCT queries
  - Performance tests with larger datasets

#### Testing Improvements:
- Removed all SQL and debugging logs from test output for cleaner test 
- Added performance comparison between normal and GROUP BY queries
- Added more edge cases to ensure robust behavior